### PR TITLE
fix: support credentials in url

### DIFF
--- a/src/api/audits/methods.test.ts
+++ b/src/api/audits/methods.test.ts
@@ -167,6 +167,29 @@ describe('audit methods', () => {
       });
     });
 
+    describe('when using credentials in url', () => {
+      it('passes the options along to lighthouse', async () => {
+        await triggerAudit(conn, 'https://user:pass@spotify.com');
+        await wait(); // wait for background job to flush
+        expect(waitOn).toHaveBeenCalledWith(
+          expect.objectContaining({
+            auth: {
+              username: 'user',
+              password: 'pass',
+            },
+            resources: ['https-get://spotify.com/'],
+          }),
+        );
+        expect(lighthouse).toHaveBeenCalledWith(
+          'https://user:pass@spotify.com',
+          expect.objectContaining({ port: 9222 }),
+          expect.objectContaining({
+            extends: 'lighthouse:default',
+          }),
+        );
+      });
+    });
+
     describe('when using awaitAuditCompleted', () => {
       it('returns a completed audit', async () => {
         const audit = await triggerAudit(conn, 'https://spotify.com', {

--- a/src/api/audits/methods.ts
+++ b/src/api/audits/methods.ts
@@ -105,11 +105,17 @@ async function runAudit(
 
   try {
     logger.debug('Waiting for URL to be UP ...');
-    const urlWithoutProtocol = url.replace(HTTP_RE, '');
-    const urlToWaitOn = `http-get://${urlWithoutProtocol}`;
+    const u = new URL(url);
+    // Remove the colon from the protocol
+    const protocol = u.protocol.substring(0, u.protocol.length - 1);
+    // Craft url and options according to waitOn specs
+    const urlToWaitOn = `${protocol}-get://${u.host}${u.pathname}${u.search}`;
     const waitOnOpts = {
       resources: [urlToWaitOn],
       timeout: upTimeout,
+      auth: u.username
+        ? { username: u.username, password: u.password }
+        : undefined,
     };
     await waitOn(waitOnOpts);
   } catch (err) {


### PR DESCRIPTION
Dependency bump seems to have caused the feature to add basic auth in urls to fail, e.g. `https://user:pass@spotify.com`. This PR fixes that.

Signed-off-by: Erik Larsson <erik.larsson@schibsted.com>