### PR TITLE
Fix typo in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ You may nest the [express app](https://expressjs.com/) that the lighthouse-audit
 
 ```js
 import express from 'express';
-import { getApp as getLighthouseAuditServerApp } from '@spotify/lighthouse-audit-server';
+import { getApp as getLighthouseAuditServerApp } from '@spotify/lighthouse-audit-service';
 
 async function startup() {
   const app = express();


### PR DESCRIPTION
When using this repo locally, I noticed that there's a typo in one of the examples in the README: essentially, the example imports from `'@spotify/lighthouse-audit-server'` instead of `'@spotify/lighthouse-audit-service'`. This PR fixes that typo.