### PR TITLE
fix: Adds pagination and inner-pagination to website and audit routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,13 @@ A simple way to trial this tool is with the following docker compose file which 
 version: '3.1'
 
 services:
-
   db:
     image: postgres:latest
     restart: always
     environment:
       POSTGRES_USER: dbuser
       POSTGRES_PASSWORD: example
-  
+
   lighthouse:
     image: spotify/lighthouse-audit-service:latest
     environment:
@@ -46,9 +45,8 @@ services:
       PGPASSWORD: example
       LAS_PORT: 4008
     ports:
-      - "4008:4008"
+      - '4008:4008'
 ```
-
 
 ### As an npm package
 
@@ -167,15 +165,24 @@ We are currently [seeking contributions](https://github.com/spotify/lighthouse-a
       - `lighthouseConfig: LighthouseConfig` - custom [Lighthouse config](https://github.com/GoogleChrome/lighthouse/blob/master/docs/configuration.md) to be used when running the audit.
 - `DELETE /v1/audits/:auditId` - delete an audit
 
+Basic pagination is available on routes which return multiple items.
+`offset` and `limit` will be recognized, defaulting to 0 and 25 respectively.
+
 #### Website routes
 
 - `GET /v1/websites` - list of audits grouped by url
 - `GET /v1/websites/:websiteUrl` - get the audits associated with this url. _be sure to uri encode that url!_
 - `GET /v1/audits/:auditId/website` - get the group of audits associated with the url used for this audit.
 
-### Programatic
+Basic pagination is available on REST routes which return multiple items.
+`offset` and `limit` will be recognized, defaulting to `0` and `25` respectively.
 
-All of the API methods exposed on REST are also exposed programmatically.
+For these website routes, an additional set of pagination is available to page the audits returned per website as well.
+`audit-offset` and `audit-limit` default to `0` and `25` respectively, and will limit the returned audit size per website response.
+
+### Programmatic
+
+All the API methods exposed on REST are also exposed programmatically.
 
 #### Server
 

--- a/src/api/listHelpers.ts
+++ b/src/api/listHelpers.ts
@@ -60,11 +60,13 @@ export function listResponseFactory<Item>(
 
 export function listOptionsFromQuery(
   query: Query,
+  prefix = '',
   defaultLimit = 25,
   defaultOffset = 0,
 ): ListRequest {
-  const { limit: limitStr = defaultLimit, offset: offsetStr = defaultOffset } =
-    query;
+  const limitStr = query[`${prefix}limit`] ?? defaultLimit;
+  const offsetStr = query[`${prefix}offset`] ?? defaultOffset;
+  // const { limit: limitStr = defaultLimit, offset: offsetStr = defaultOffset } = query;
   const limit = +limitStr;
   const offset = +offsetStr;
 

--- a/src/api/websites/db.test.ts
+++ b/src/api/websites/db.test.ts
@@ -115,6 +115,18 @@ describe('audit db methods', () => {
       expect(website.lastAudit).toBeInstanceOf(Object);
     });
 
+    it('pages properly', async () => {
+      const website = await retrieveWebsiteByAuditId(
+        conn,
+        audit.id,
+        { limit: 1, offset: 0 },
+        { limit: 1, offset: 0 },
+      );
+      expect(website.url).toBe('https://spotify.com/se');
+      expect(website.audits).toHaveLength(1);
+      expect(website.lastAudit).toBeInstanceOf(Object);
+    });
+
     describe('when url doesnt exist', () => {
       it('throws a NotFoundError', async () => {
         await expect(
@@ -198,7 +210,8 @@ describe('audit db methods', () => {
 
     describe('when no rows are in the db', () => {
       beforeEach(async () => {
-        await conn.query(SQL`DELETE FROM lighthouse_audits`);
+        await conn.query(SQL`DELETE
+                             FROM lighthouse_audits`);
       });
 
       it('returns correctly', async () => {
@@ -210,7 +223,9 @@ describe('audit db methods', () => {
 
   describe('#retrieveAuditCount', () => {
     beforeEach(async () => {
-      await conn.query(SQL`DELETE FROM lighthouse_audits; COMMIT;`);
+      await conn.query(SQL`DELETE
+                           FROM lighthouse_audits;
+      COMMIT;`);
 
       const first = persistAudit(
         conn,
@@ -241,7 +256,9 @@ describe('audit db methods', () => {
     });
 
     afterEach(async () => {
-      await conn.query(SQL`DELETE FROM lighthouse_audits; COMMIT;`);
+      await conn.query(SQL`DELETE
+                           FROM lighthouse_audits;
+      COMMIT;`);
     });
 
     it('returns the count, properly grouped', async () => {
@@ -250,7 +267,9 @@ describe('audit db methods', () => {
 
     describe('when there are no entries', () => {
       beforeEach(async () => {
-        await conn.query(SQL`DELETE FROM lighthouse_audits; COMMIT;`);
+        await conn.query(SQL`DELETE
+                             FROM lighthouse_audits;
+        COMMIT;`);
       });
 
       it('returns zero', async () => {

--- a/src/api/websites/db.ts
+++ b/src/api/websites/db.ts
@@ -29,10 +29,19 @@ export interface WebsiteRow {
 export async function retrieveWebsiteByUrl(
   conn: DbConnectionType,
   url: string,
+  websiteOptions?: ListRequest,
+  auditOptions?: ListRequest,
 ): Promise<Website> {
-  const res = await retrieveWebsiteList(conn, {
-    where: SQL`WHERE url = ${url}`,
-  });
+  const res = await retrieveWebsiteList(
+    conn,
+    Object.assign(
+      {
+        where: SQL`WHERE url = ${url}`,
+      },
+      websiteOptions,
+    ),
+    auditOptions,
+  );
   if (res.length === 0)
     throw new NotFoundError(`no audited website found for url "${url}"`);
   return res[0];
@@ -41,10 +50,19 @@ export async function retrieveWebsiteByUrl(
 export async function retrieveWebsiteByAuditId(
   conn: DbConnectionType,
   auditId: string,
+  websiteOptions?: ListRequest,
+  auditOptions?: ListRequest,
 ): Promise<Website> {
-  const res = await retrieveWebsiteList(conn, {
-    where: SQL`WHERE url IN (SELECT url FROM lighthouse_audits w WHERE w.id = ${auditId})`,
-  });
+  const res = await retrieveWebsiteList(
+    conn,
+    Object.assign(
+      {
+        where: SQL`WHERE url IN (SELECT url FROM lighthouse_audits w WHERE w.id = ${auditId})`,
+      },
+      websiteOptions ?? {},
+    ),
+    auditOptions,
+  );
   if (res.length === 0)
     throw new NotFoundError(`website found for audit id "${auditId}"`);
   return res[0];
@@ -52,27 +70,26 @@ export async function retrieveWebsiteByAuditId(
 
 export async function retrieveWebsiteList(
   conn: DbConnectionType,
-  options: ListRequest,
+  websiteOptions: ListRequest,
+  auditOptions?: ListRequest,
 ): Promise<Website[]> {
-  let query = SQL`
-    SELECT
-      distinct url,
-      MAX(time_created) as time_last_created,
-      array(
-        SELECT to_json(n.*)::text
-        FROM lighthouse_audits n
-        WHERE n.url = o.url
-        ORDER BY time_created DESC
-      ) as audits_json
-    FROM lighthouse_audits o
-  `;
-  if (options.where) {
+  let innerQuery = SQL`SELECT to_json(n.*) ::text
+                       FROM lighthouse_audits n
+                       WHERE n.url = o.url
+                       ORDER BY time_created DESC`;
+  if (auditOptions)
+    innerQuery = addListRequestToQuery(innerQuery, auditOptions);
+
+  let query = SQL`SELECT distinct url, MAX(time_created) as time_last_created, array(`;
+  query.append(innerQuery);
+  query.append(SQL`) as audits_json      FROM lighthouse_audits o  `);
+  if (websiteOptions.where) {
     query.append(`\n`);
-    query.append(options.where);
+    query.append(websiteOptions.where);
   }
   query = query.append(SQL`\nGROUP BY url`);
   query = query.append(SQL`\nORDER BY time_last_created DESC`);
-  query = addListRequestToQuery(query, options);
+  query = addListRequestToQuery(query, websiteOptions);
   const queryResult = await conn.query<WebsiteRow>(query);
   return queryResult.rows.map(Website.buildForDbRow);
 }
@@ -81,7 +98,8 @@ export async function retrieveWebsiteTotal(
   conn: DbConnectionType,
 ): Promise<number> {
   const res = await conn.query<{ total_count: string }>(
-    SQL`SELECT COUNT(distinct url) as total_count FROM lighthouse_audits`,
+    SQL`SELECT COUNT(distinct url) as total_count
+        FROM lighthouse_audits`,
   );
   return +res.rows[0].total_count;
 }

--- a/src/api/websites/routes.test.ts
+++ b/src/api/websites/routes.test.ts
@@ -94,6 +94,37 @@ describe('audit routes', () => {
           expect(methods.getWebsiteByAuditId).toHaveBeenLastCalledWith(
             conn,
             audit.id,
+            { limit: 25, offset: 0 },
+            { limit: 25, offset: 0 },
+          );
+
+          expect(res.body.url).toBe('https://spotify.com');
+          expect(res.body.audits).toHaveLength(1);
+          expect(res.body.lastAudit.status).toBe('COMPLETED');
+          expect(res.body.lastAudit.timeCreated).toEqual(
+            audit.timeCreated?.toISOString(),
+          );
+          expect(res.body.lastAudit.timeCompleted).toEqual(
+            audit.timeCompleted?.toISOString(),
+          );
+          expect(res.body.lastAudit.id).toEqual(audit.id);
+        });
+    });
+
+    it('properly parses page data', async () => {
+      await request(app)
+        .get(
+          `/v1/audits/${audit.id}/website?limit=2&offset=0&audit-limit=1&audit-offset=0`,
+        )
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .then(res => {
+          expect(methods.getWebsiteByAuditId).toHaveBeenLastCalledWith(
+            conn,
+            audit.id,
+            { limit: 2, offset: 0 },
+            { limit: 1, offset: 0 },
           );
 
           expect(res.body.url).toBe('https://spotify.com');
@@ -135,6 +166,8 @@ describe('audit routes', () => {
           expect(methods.getWebsiteByUrl).toHaveBeenLastCalledWith(
             conn,
             'https://spotify.com',
+            { limit: 25, offset: 0 },
+            { limit: 25, offset: 0 },
           );
           expect(res.body.url).toBe('https://spotify.com');
           expect(res.body.audits).toHaveLength(1);

--- a/src/api/websites/routes.ts
+++ b/src/api/websites/routes.ts
@@ -24,7 +24,12 @@ export function bindRoutes(router: Router, conn: DbConnectionType): void {
   router.get(
     '/v1/audits/:auditId/website',
     async (req: Request<{ auditId: string }>, res: Response<WebsiteBody>) => {
-      const response = await getWebsiteByAuditId(conn, req.params.auditId);
+      const response = await getWebsiteByAuditId(
+        conn,
+        req.params.auditId,
+        listOptionsFromQuery(req.query),
+        listOptionsFromQuery(req.query, 'audit-'),
+      );
       res.json(response.body);
     },
   );
@@ -35,7 +40,12 @@ export function bindRoutes(router: Router, conn: DbConnectionType): void {
       req: Request<{ websiteUrl: string }>,
       res: Response<WebsiteBody>,
     ) => {
-      const response = await getWebsiteByUrl(conn, req.params.websiteUrl);
+      const response = await getWebsiteByUrl(
+        conn,
+        req.params.websiteUrl,
+        listOptionsFromQuery(req.query),
+        listOptionsFromQuery(req.query, 'audit-'),
+      );
       res.json(response.body);
     },
   );


### PR DESCRIPTION
Extends the `listOptionsFromQuery` function, allowing prefixed parameters.
Lets pagination occur on inner queries for the `website` routes.
Extends `db` functions to take in optional `listOptions`.

This fixes https://github.com/spotify/lighthouse-audit-service/issues/77