### PR TITLE
fix(audits): fix report categories displayed in the wrong order

### DIFF
--- a/src/db/migrations/0002_fix_report_json_column.sql
+++ b/src/db/migrations/0002_fix_report_json_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE lighthouse_audits ALTER COLUMN report_json TYPE json


### PR DESCRIPTION
# Current behaviour : 
![Peek 2022-08-22 07-42](https://user-images.githubusercontent.com/29628106/185847535-4cd6369a-fd01-49e0-8d00-cf0bfbccd760.gif)

# With this patch :
![Peek 2022-08-22 07-43](https://user-images.githubusercontent.com/29628106/185847579-5c6891f9-3d8b-45c8-80fc-7e6d64a3e3ef.gif)
